### PR TITLE
[Bug fix] Running database query before migration

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\View;
 use App\Models\Category;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\App;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -38,6 +39,10 @@ class AppServiceProvider extends ServiceProvider
         });
 
         Paginator::useBootstrap();
+
+        if (App::runningInConsole()) {
+            return;
+        }
 
         if (Cache::has('search_categories')) {
             $search_categories = Cache::get('search_categories');


### PR DESCRIPTION
## Bug Detail:
- This bug happens in the artisan migration process. The app query for `categories` table records before the migration start. This is due to the `boot` function, it preloads `categories` data for caching.

## What does this PR do?
- [x] Check if the current section is running through CLI or not before preloads `categories` data.

## Evidence:
#### Before
![image](https://user-images.githubusercontent.com/37581250/135812906-073083d6-e0c2-437d-94c3-7864d212841e.png)
![image](https://user-images.githubusercontent.com/37581250/135812995-4ba02c5b-1ffe-49b2-a817-3d3adc032070.png)

#### After
![image](https://user-images.githubusercontent.com/37581250/135813105-8eeae570-9735-438d-b8e2-1668ed37792f.png)
